### PR TITLE
ci: run the integration tests through failsafe and verify the shaded jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,49 +61,14 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
-      - name: Build and run unit tests (lance-flink-${{ matrix.flink }})
-        run: mvn -B -ntp -am -pl lance-flink-${{ matrix.flink }} verify -DskipITs
-
-      - name: Upload surefire reports on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: surefire-reports-flink${{ matrix.flink }}-jdk${{ matrix.java }}
-          path: '**/target/surefire-reports/**'
-          retention-days: 7
-
-  integration-test:
-    name: IT / Flink ${{ matrix.flink }}
-    runs-on: ubuntu-latest
-    # The integration tests build the shaded jar and drive a real Lance directory
-    # namespace, so they need more headroom than the unit-test jobs.
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        # One JDK is enough here: the integration tests exercise the connector
-        # against Lance, not the JDK, and the unit-test matrix above already
-        # covers 11/17/21.
-        flink: ["1.18", "1.19", "1.20"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
-
-      - name: Run integration tests (lance-flink-${{ matrix.flink }})
+      - name: Build and run tests (lance-flink-${{ matrix.flink }})
         run: mvn -B -ntp -am -pl lance-flink-${{ matrix.flink }} verify
 
       - name: Upload test reports on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: it-reports-flink${{ matrix.flink }}
+          name: test-reports-flink${{ matrix.flink }}-jdk${{ matrix.java }}
           path: |
             **/target/surefire-reports/**
             **/target/failsafe-reports/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           cache: maven
 
       - name: Build and run unit tests (lance-flink-${{ matrix.flink }})
-        run: mvn -B -ntp -am -pl lance-flink-${{ matrix.flink }} verify
+        run: mvn -B -ntp -am -pl lance-flink-${{ matrix.flink }} verify -DskipITs
 
       - name: Upload surefire reports on failure
         if: failure()
@@ -70,5 +70,42 @@ jobs:
         with:
           name: surefire-reports-flink${{ matrix.flink }}-jdk${{ matrix.java }}
           path: '**/target/surefire-reports/**'
+          retention-days: 7
+
+  integration-test:
+    name: IT / Flink ${{ matrix.flink }}
+    runs-on: ubuntu-latest
+    # The integration tests build the shaded jar and drive a real Lance directory
+    # namespace, so they need more headroom than the unit-test jobs.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # One JDK is enough here: the integration tests exercise the connector
+        # against Lance, not the JDK, and the unit-test matrix above already
+        # covers 11/17/21.
+        flink: ["1.18", "1.19", "1.20"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run integration tests (lance-flink-${{ matrix.flink }})
+        run: mvn -B -ntp -am -pl lance-flink-${{ matrix.flink }} verify
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: it-reports-flink${{ matrix.flink }}
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
           retention-days: 7
 

--- a/lance-flink-1.18/pom.xml
+++ b/lance-flink-1.18/pom.xml
@@ -222,8 +222,8 @@
                 </executions>
             </plugin>
 
-            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
-                 而 failIfNoTests=true 会让它直接失败。 -->
+            <!-- failsafe is declared on the jar modules only: the root aggregator has
+                 no test classes of its own, and failIfNoTests=true would fail it. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/lance-flink-1.18/pom.xml
+++ b/lance-flink-1.18/pom.xml
@@ -222,6 +222,13 @@
                 </executions>
             </plugin>
 
+            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
+                 而 failIfNoTests=true 会让它直接失败。 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/lance-flink-1.19/pom.xml
+++ b/lance-flink-1.19/pom.xml
@@ -221,8 +221,8 @@
                 </executions>
             </plugin>
 
-            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
-                 而 failIfNoTests=true 会让它直接失败。 -->
+            <!-- failsafe is declared on the jar modules only: the root aggregator has
+                 no test classes of its own, and failIfNoTests=true would fail it. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/lance-flink-1.19/pom.xml
+++ b/lance-flink-1.19/pom.xml
@@ -221,6 +221,13 @@
                 </executions>
             </plugin>
 
+            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
+                 而 failIfNoTests=true 会让它直接失败。 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/lance-flink-1.20/pom.xml
+++ b/lance-flink-1.20/pom.xml
@@ -221,8 +221,8 @@
                 </executions>
             </plugin>
 
-            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
-                 而 failIfNoTests=true 会让它直接失败。 -->
+            <!-- failsafe is declared on the jar modules only: the root aggregator has
+                 no test classes of its own, and failIfNoTests=true would fail it. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/lance-flink-1.20/pom.xml
+++ b/lance-flink-1.20/pom.xml
@@ -221,6 +221,13 @@
                 </executions>
             </plugin>
 
+            <!-- 只在打 jar 的模块上挂 failsafe：根聚合模块没有测试类，
+                 而 failIfNoTests=true 会让它直接失败。 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,38 @@
                     <version>3.1.2</version>
                 </plugin>
 
+                <!-- Maven Failsafe 插件（跑 *ITCase 集成测试）
+
+                     classesDirectory 指向 target/classes 是必须的：shade 在 package 阶段
+                     把主 artifact 换成了 relocate 过 arrow 的 fat jar，而测试是按未 relocate
+                     的 arrow 签名编译的，failsafe 默认针对主 artifact 跑就会撞
+                     NoSuchMethodError。shaded jar 自身的正确性由 LanceShadedJarITCase
+                     单独校验。 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*ITCase.java</include>
+                        </includes>
+                        <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                        <systemPropertyVariables>
+                            <lance.shaded.jar.dir>${project.build.directory}</lance.shaded.jar.dir>
+                            <lance.shaded.jar.name>${project.build.finalName}.jar</lance.shaded.jar.name>
+                        </systemPropertyVariables>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>integration-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
                 <!-- Build Helper Maven Plugin (用于添加额外源码目录) -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -465,6 +497,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -292,8 +292,16 @@
                     <version>3.1.2</version>
                     <configuration>
                         <includes>
+                            <!-- Failsafe's defaults, restated because listing any include
+                                 replaces the whole default set. *IT/IT* are here so a test
+                                 following the more common Maven naming does not go unnoticed. -->
                             <include>**/*ITCase.java</include>
+                            <include>**/IT*.java</include>
+                            <include>**/*IT.java</include>
                         </includes>
+                        <!-- Without this, a pattern that matches nothing exits 0 and a green
+                             build stops proving the integration tests ran at all. -->
+                        <failIfNoTests>true</failIfNoTests>
                         <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                         <systemPropertyVariables>
                             <lance.shaded.jar.dir>${project.build.directory}</lance.shaded.jar.dir>
@@ -497,10 +505,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
+        <!-- Arrow 通过反射拿 java.nio.Buffer.address 来做堆外内存访问。JDK 17 起这属于
+             强封装，MemoryUtil 静态初始化会直接抛 RuntimeException，提示补这个 add-opens。
+             JDK 11 上只是一条 illegal reflective access 警告，加了同样无害。
+             surefire / failsafe 默认读 ${argLine}，jacoco:prepare-agent 会把 javaagent
+             追加到这个属性上而不是覆盖，所以两者能共存。 -->
+        <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+
         <!-- Lance Flink Connector 版本 -->
         <lance-flink.version>0.1.0</lance-flink.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <!-- Arrow 通过反射拿 java.nio.Buffer.address 来做堆外内存访问。JDK 17 起这属于
-             强封装，MemoryUtil 静态初始化会直接抛 RuntimeException，提示补这个 add-opens。
-             JDK 11 上只是一条 illegal reflective access 警告，加了同样无害。
-             surefire / failsafe 默认读 ${argLine}，jacoco:prepare-agent 会把 javaagent
-             追加到这个属性上而不是覆盖，所以两者能共存。 -->
+        <!-- Arrow reaches java.nio.Buffer.address by reflection to get at off-heap memory.
+             JDK 17 encapsulates that, so MemoryUtil's static initializer throws a
+             RuntimeException naming this exact flag. On JDK 11 it is only an
+             illegal-reflective-access warning, and passing the flag there is harmless.
+             surefire and failsafe both read ${argLine} by default, and
+             jacoco:prepare-agent appends its -javaagent to this property rather than
+             replacing it, so the two coexist. -->
         <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
 
         <!-- Lance Flink Connector 版本 -->
@@ -286,13 +288,14 @@
                     <version>3.1.2</version>
                 </plugin>
 
-                <!-- Maven Failsafe 插件（跑 *ITCase 集成测试）
+                <!-- Maven Failsafe (runs the *ITCase integration tests).
 
-                     classesDirectory 指向 target/classes 是必须的：shade 在 package 阶段
-                     把主 artifact 换成了 relocate 过 arrow 的 fat jar，而测试是按未 relocate
-                     的 arrow 签名编译的，failsafe 默认针对主 artifact 跑就会撞
-                     NoSuchMethodError。shaded jar 自身的正确性由 LanceShadedJarITCase
-                     单独校验。 -->
+                     classesDirectory has to point at target/classes. At package time
+                     shade replaces the main artifact with a fat jar in which arrow is
+                     relocated, while the tests are compiled against the plain arrow
+                     signatures, so failsafe running against the main artifact would hit
+                     NoSuchMethodError. The shaded jar is checked separately by
+                     LanceShadedJarITCase. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>

--- a/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Checks the shaded jar the build produces, rather than the classes the other tests run against.
+ *
+ * <p>The rest of the suite runs on {@code target/classes}, where Arrow is not relocated. That is
+ * deliberate: the tests are compiled against the plain Arrow packages. It does mean nothing else
+ * exercises the jar users actually deploy, so this case loads that jar in an isolated
+ * classloader and asserts the relocation held.
+ *
+ * <p>The jar path comes from system properties set by failsafe. When they are absent, as in an
+ * IDE run, the case is skipped rather than failed.
+ */
+@DisplayName("Shaded Jar Relocation Tests")
+class LanceShadedJarITCase {
+
+    private static final String SHADED_ARROW_SCHEMA =
+            "org.apache.flink.connector.lance.shaded.arrow.vector.types.pojo.Schema";
+    private static final String PLAIN_ARROW_SCHEMA = "org.apache.arrow.vector.types.pojo.Schema";
+
+    private static File shadedJar() {
+        String dir = System.getProperty("lance.shaded.jar.dir");
+        String name = System.getProperty("lance.shaded.jar.name");
+        assumeTrue(dir != null && name != null, "shaded jar location not provided by the build");
+        File jar = new File(dir, name);
+        assumeTrue(jar.isFile(), "shaded jar not built yet: " + jar);
+        return jar;
+    }
+
+    private static ShadedJarLoader isolatedLoader(File jar) throws Exception {
+        return new ShadedJarLoader(jar);
+    }
+
+    /**
+     * Answers connector and Arrow class requests from the jar alone, and delegates the rest to the
+     * parent.
+     *
+     * <p>A loader with no parent at all would be simpler, but then reflecting over a connector
+     * method fails: resolving a signature such as {@code toArrowSchema(RowType)} needs the Flink
+     * API, which the jar does not bundle. Delegating everything to the parent is no good either,
+     * since parent-first would answer both prefixes from the test classpath, where Arrow is not
+     * relocated — the relocation assertions would then pass or fail on the wrong classes.
+     */
+    private static final class ShadedJarLoader extends URLClassLoader {
+
+        private static final String[] JAR_ONLY = {
+            "org.apache.flink.connector.lance.", "org.apache.arrow."
+        };
+
+        ShadedJarLoader(File jar) throws Exception {
+            super(new URL[] {jar.toURI().toURL()}, ShadedJarLoader.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            for (String prefix : JAR_ONLY) {
+                if (name.startsWith(prefix)) {
+                    return loadFromJarOnly(name, resolve);
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> loadFromJarOnly(String name, boolean resolve)
+                throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    // Throws ClassNotFoundException when the jar does not carry the class, which
+                    // is what the "plain Arrow is absent" assertion relies on.
+                    loaded = findClass(name);
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Arrow is relocated in the shaded jar")
+    void testArrowIsRelocated() throws Exception {
+        File jar = shadedJar();
+        try (URLClassLoader loader = isolatedLoader(jar)) {
+            assertThat(loader.loadClass(SHADED_ARROW_SCHEMA)).isNotNull();
+
+            assertThatThrownBy(() -> loader.loadClass(PLAIN_ARROW_SCHEMA))
+                    .as("non-relocated Arrow must not be bundled")
+                    .isInstanceOf(ClassNotFoundException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("Connector signatures reference the relocated Arrow packages")
+    void testConnectorSignaturesRelocated() throws Exception {
+        File jar = shadedJar();
+        try (URLClassLoader loader = isolatedLoader(jar)) {
+            Class<?> converter =
+                    loader.loadClass(
+                            "org.apache.flink.connector.lance.converter.LanceTypeConverter");
+            Method toArrowSchema = null;
+            for (Method m : converter.getDeclaredMethods()) {
+                if (m.getName().equals("toArrowSchema")) {
+                    toArrowSchema = m;
+                    break;
+                }
+            }
+            assertThat(toArrowSchema).as("toArrowSchema should exist").isNotNull();
+            assertThat(toArrowSchema.getReturnType().getName())
+                    .as("the return type must be the relocated Arrow Schema")
+                    .isEqualTo(SHADED_ARROW_SCHEMA);
+        }
+    }
+}

--- a/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
@@ -25,9 +25,13 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -39,21 +43,21 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * classloader and asserts the relocation held.
  *
  * <p>The jar path comes from system properties set by failsafe. When they are absent, as in an
- * IDE run, the case is skipped rather than failed.
+ * IDE run, the case is skipped rather than failed. A missing jar when the build did pass the
+ * properties is a failure, not a skip -- shade runs at {@code package}, before this phase.
  */
 @DisplayName("Shaded Jar Relocation Tests")
 class LanceShadedJarITCase {
 
     private static final String SHADED_ARROW_SCHEMA =
             "org.apache.flink.connector.lance.shaded.arrow.vector.types.pojo.Schema";
-    private static final String PLAIN_ARROW_SCHEMA = "org.apache.arrow.vector.types.pojo.Schema";
 
     private static File shadedJar() {
         String dir = System.getProperty("lance.shaded.jar.dir");
         String name = System.getProperty("lance.shaded.jar.name");
         assumeTrue(dir != null && name != null, "shaded jar location not provided by the build");
         File jar = new File(dir, name);
-        assumeTrue(jar.isFile(), "shaded jar not built yet: " + jar);
+        assertThat(jar).as("the build should have produced the shaded jar by now").isFile();
         return jar;
     }
 
@@ -112,12 +116,25 @@ class LanceShadedJarITCase {
     @DisplayName("Arrow is relocated in the shaded jar")
     void testArrowIsRelocated() throws Exception {
         File jar = shadedJar();
-        try (URLClassLoader loader = isolatedLoader(jar)) {
+        try (ShadedJarLoader loader = isolatedLoader(jar)) {
+            // Throws ClassNotFoundException if the relocation stopped happening.
             assertThat(loader.loadClass(SHADED_ARROW_SCHEMA)).isNotNull();
+        }
 
-            assertThatThrownBy(() -> loader.loadClass(PLAIN_ARROW_SCHEMA))
-                    .as("non-relocated Arrow must not be bundled")
-                    .isInstanceOf(ClassNotFoundException.class);
+        // One class is not enough. Relocations get carved out per package often enough --
+        // a JNI package that breaks when its classes move is the usual reason -- and such an
+        // exclusion leaves plain Arrow in the jar while the class above still resolves. So
+        // walk every entry instead of trusting a single probe.
+        try (JarFile entries = new JarFile(jar)) {
+            List<String> plainArrow =
+                    entries.stream()
+                            .map(ZipEntry::getName)
+                            .filter(n -> n.startsWith("org/apache/arrow/") && n.endsWith(".class"))
+                            .limit(10)
+                            .collect(Collectors.toList());
+            assertThat(plainArrow)
+                    .as("non-relocated Arrow classes must not be bundled (first 10 shown)")
+                    .isEmpty();
         }
     }
 
@@ -125,21 +142,23 @@ class LanceShadedJarITCase {
     @DisplayName("Connector signatures reference the relocated Arrow packages")
     void testConnectorSignaturesRelocated() throws Exception {
         File jar = shadedJar();
-        try (URLClassLoader loader = isolatedLoader(jar)) {
+        try (ShadedJarLoader loader = isolatedLoader(jar)) {
             Class<?> converter =
                     loader.loadClass(
                             "org.apache.flink.connector.lance.converter.LanceTypeConverter");
-            Method toArrowSchema = null;
-            for (Method m : converter.getDeclaredMethods()) {
-                if (m.getName().equals("toArrowSchema")) {
-                    toArrowSchema = m;
-                    break;
-                }
-            }
-            assertThat(toArrowSchema).as("toArrowSchema should exist").isNotNull();
-            assertThat(toArrowSchema.getReturnType().getName())
+            List<Method> toArrowSchema =
+                    Arrays.stream(converter.getDeclaredMethods())
+                            .filter(m -> m.getName().equals("toArrowSchema"))
+                            .collect(Collectors.toList());
+
+            assertThat(toArrowSchema).as("toArrowSchema should exist").isNotEmpty();
+            // Every overload, not just whichever one reflection happens to return first.
+            assertThat(toArrowSchema)
                     .as("the return type must be the relocated Arrow Schema")
-                    .isEqualTo(SHADED_ARROW_SCHEMA);
+                    .allSatisfy(
+                            m ->
+                                    assertThat(m.getReturnType().getName())
+                                            .isEqualTo(SHADED_ARROW_SCHEMA));
         }
     }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceShadedJarITCase.java
@@ -73,7 +73,7 @@ class LanceShadedJarITCase {
      * method fails: resolving a signature such as {@code toArrowSchema(RowType)} needs the Flink
      * API, which the jar does not bundle. Delegating everything to the parent is no good either,
      * since parent-first would answer both prefixes from the test classpath, where Arrow is not
-     * relocated — the relocation assertions would then pass or fail on the wrong classes.
+     * relocated, and the relocation assertions would then pass or fail on the wrong classes.
      */
     private static final class ShadedJarLoader extends URLClassLoader {
 


### PR DESCRIPTION
## What this does

The repo has five `*ITCase` classes and none of them had ever run. There is no `maven-failsafe-plugin` in the build, and `*ITCase` does not match surefire's default includes (`*Test`, `*Tests`, `*TestCase`), so `mvn verify` walked straight past them. #55 listed this as a follow-up; this is it.

Four changes:

1. Wire `maven-failsafe-plugin` into the three jar modules so `verify` runs the ITs.
2. Add `LanceShadedJarITCase`, for the reason in the next section.
3. Set `argLine` so Arrow can allocate off-heap on JDK 17+, which is what turning the ITs on immediately exposed.
4. In the workflow, rename the build step and widen the failure artifact so it carries the failsafe reports next to surefire's. The `mvn` command does not change: `verify` now covers the ITs, so the existing 8-job matrix picks them up as it stands.

## Why failsafe has to target `target/classes`

`maven-shade-plugin` relocates `org.apache.arrow` to `org.apache.flink.connector.lance.shaded.arrow` at `package`, replacing the main artifact. failsafe defaults to that main artifact. The tests compile against plain Arrow, so running them against the shaded jar fails with `NoSuchMethodError`: the signatures moved.

```
target/classes                    -> toArrowSchema(RowType) : org.apache.arrow.vector.types.pojo.Schema
target/lance-flink-1.18-0.1.0.jar -> toArrowSchema(RowType) : org.apache.flink.connector.lance.shaded.arrow.vector.types.pojo.Schema
```

Hence `<classesDirectory>${project.build.outputDirectory}</classesDirectory>`. The cost is that the shaded jar, which is what users actually deploy, then has no automated check at all. That is what `LanceShadedJarITCase` covers: it loads the jar in its own classloader and asserts that no plain-Arrow class is bundled, and that the connector's public signatures reference the relocated packages.

## Guarding against silent no-ops

Three ways a green build could have stopped proving the ITs ran, all closed here:

- Listing any `<includes>` pattern replaces failsafe's whole default set, and `failIfNoTests` defaults to false, so a pattern matching nothing exits 0. The defaults are restated and `failIfNoTests` is on.
- The shaded-jar check first probed a single class name. A per-package relocation carve-out, which is the usual fix when a JNI package breaks on being moved, leaves plain Arrow in the jar while that one class still resolves. It now walks every jar entry.
- A missing jar was an `assumeTrue`, so it skipped. shade runs at `package`, before this phase, so if the build handed us a path the jar should be there. It asserts now.

failsafe hangs off the three jar modules rather than the root aggregator, since the root has no test classes of its own and `failIfNoTests=true` would fail it there.

## Why one matrix rather than separate IT jobs

Giving the ITs their own jobs is the obvious shape and it does not pay off here, because a job in the existing matrix already does everything the ITs need. Here is a `-DskipITs` job, `Flink 1.18 / JDK 17`, by phase:

```
surefire:test               19:48:57
jar:jar                     19:49:05
shade:shade                 19:49:05    <- 280MB fat jar, built anyway
failsafe:integration-test   19:49:43    <- "Tests are skipped."
```

`-DskipITs` skips failsafe and nothing else. The reactor compile and the shade run either way, and failsafe's own 44 tests take 4.7 seconds. So a dedicated IT job would pay for a second full build to buy 4.7 seconds of coverage, and the overlap would grow with every unit test added.

Keeping them in the existing matrix also widens IT coverage from one JDK to all eight Flink x JDK combinations. The JDK axis is not idle for ITs: the `MemoryUtil` failure below reproduces on 17+ and only warns on 11. The eight jobs on this branch run 57 to 77 seconds each.

## Test plan

`mvn -am -pl lance-flink-<v> verify` was run locally for every Flink x JDK pair the matrix covers, and all eight report 44 ITs and 186 unit tests:

| | JDK 11 | JDK 17 | JDK 21 |
|---|---|---|---|
| 1.18 | 44 | 44 | not in matrix |
| 1.19 | 44 | 44 | 44 |
| 1.20 | 44 | 44 | 44 |

44 = `LanceSqlITCase` 20 + `LanceConnectorITCase` 15 + `LanceTimeTravelITCase` 4 + `LanceNamespaceCatalogITCase` 3 + `LanceShadedJarITCase` 2. One of the time-travel cases is an opt-in export gated on `$TT_EXPORT_DIR` and reports as skipped, so a green run shows `Skipped: 1`. `-DskipITs` still works for a local unit-only run, verified on 1.18/JDK 17 and 1.20/JDK 21.

Both new checks were reverse-verified by breaking what they watch:

- Comment out shade's `<relocations>` and `LanceShadedJarITCase` goes red (1 failure, 1 error).
- Add `<exclude>org.apache.arrow.memory.**</exclude>` to the relocation and the jar-walk assertion fails, listing the leaked `org/apache/arrow/memory/*.class` entries. The single-class probe stayed green on this one, which is why it was replaced.
- Point `-Dfailsafe.includes` at a pattern matching nothing and the build fails, where before `failIfNoTests` it exited 0.

## What the ITs found

`LanceTimeTravelITCase`, which came in with #56, errored on three of its four cases as soon as failsafe started running it:

```
Failed to initialize MemoryUtil. You must start Java with
  --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
```

It writes real Arrow vectors, and Arrow reaches `java.nio.Buffer.address` by reflection. JDK 17 blocks that outright, so `MemoryUtil`'s static initializer throws and the tests fail with `NoClassDefFoundError`. JDK 11 only prints an illegal-reflective-access warning, which is part of why this went unnoticed: nothing was running the class on any JDK.

Fixed by setting `argLine` as a root property. Arrow's own poms carry the same flag for their test runs. Keeping it a property rather than putting it inside surefire's `<configuration>` is what keeps jacoco working, since `prepare-agent` appends its `-javaagent` to `argLine` instead of replacing it. The build log confirms both survive:

```
argLine set to -javaagent:.../org.jacoco.agent-0.8.14-runtime.jar=destfile=... --add-opens=java.base/java.nio=ALL-UNNAMED
```
